### PR TITLE
Develop

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,9 @@ import PackageDescription
 let package = Package(
     name: "MongoKitten",
     dependencies: [
-        .Package(url: "https://github.com/PlanTeam/BSON.git", majorVersion: 1, minor: 2),
-        .Package(url: "https://github.com/SwiftX/C7.git", majorVersion: 0, minor: 1),
-        .Package(url: "https://github.com/ketzusaka/Hummingbird.git", majorVersion: 1, minor: 1),
+        .Package(url: "https://github.com/PlanTeam/BSON", majorVersion: 1, minor: 2),
+        .Package(url: "https://github.com/SwiftX/C7", majorVersion: 0, minor: 1),
+        .Package(url: "https://github.com/ketzusaka/Hummingbird", majorVersion: 1, minor: 1),
     ]
 )
 

--- a/Sources/CSArrayType+Extension.swift
+++ b/Sources/CSArrayType+Extension.swift
@@ -20,7 +20,8 @@ extension Array: CSArrayType {
 
 internal extension CSArrayType where Iterator.Element == Byte {
     internal func toHexString() -> String {
-        return self.lazy.reduce("") { $0 + String(format:"%02x", $1) }
+        // http://blog.flup.jp/2016/03/08/server-side-swift-tips-for-linux/
+        return self.lazy.reduce("") { $0 + (NSString(format:"%02x", $1).description) }
     }
     
     internal func toBase64() -> String? {


### PR DESCRIPTION
Small patch for the name issue, not sure if you want to include that in the final lib.

Also, for some reason, `String(format:` won't run on linux, but `NSString(format:` will. It was crashing my app, but after switching, doesn't crash anymore.