### PR TITLE
Make `transaction` public on collections

### DIFF
--- a/Sources/MongoKitten/MongoCollection.swift
+++ b/Sources/MongoKitten/MongoCollection.swift
@@ -68,7 +68,6 @@ import Foundation
 public final class MongoCollection: Sendable {
     // MARK: Properties
     internal let context: ServiceContext?
-    internal let transaction: MongoTransaction?
 
     /// The session this collection is bound to
     ///
@@ -83,6 +82,11 @@ public final class MongoCollection: Sendable {
     public var sessionId: SessionIdentifier? {
         return session?.sessionId
     }
+    
+    /// The transaction this collection is currently a part of
+    ///
+    /// If `nil`, the collection is not part of a transaction.
+    public let transaction: MongoTransaction?
     
     /// Whether this collection is part of a transaction
     ///


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Simply makes an existing property public, so it can be read by libraries and clients.

## Motivation and Context

I've been writing some custom extension to MongoCollection which allow me to do various operations that work for my codebase, including a custom solution for #368, but the lack of access to the transaction makes it a little more challenging to get this feature working perfectly.

Currently I'm resorting to `database.activeTransaction` but this is not the best behaviour when multiple transactions are being carried out.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~If applicable, I have updated the documentation accordingly.~~
- [ ] ~~If applicable, I have added tests to cover my changes.~~