### PR TITLE
Fix CreateIndexes.Index missing collation in CodingKeys

### DIFF
--- a/Sources/MongoKittenCore/Commands/CreateIndexes.swift
+++ b/Sources/MongoKittenCore/Commands/CreateIndexes.swift
@@ -5,7 +5,7 @@ public struct CreateIndexes: Encodable, Sendable {
     public struct Index: Encodable, Sendable {
         private enum CodingKeys: String, CodingKey {
             case name, key, unique, partialFilterExpression, sparse
-            case expireAfterSeconds, storageEngine, weights
+            case expireAfterSeconds, storageEngine, collation, weights
             case defaultLanguage = "default_language"
             case languageOverride = "language_override"
             case textIndexVersion


### PR DESCRIPTION
## Description

`CreateIndexes.Index` declares `public var collation: Collation?`, but the property is missing from the private `CodingKeys` enum. Because the type defines its own `CodingKeys`, encoding does not fall back to synthesis, so `collation` is silently dropped on the wire and never reaches the server. This PR adds `collation` to the enum so the value is encoded alongside the other index options.

## Motivation and Context

When creating a case insensitive index, e.g. one with `Collation(locale: "en", strength: 2)`, the index is stored on the server without any collation. A subsequent attempt to recreate the same index with the intended options then fails with `IndexKeySpecsConflict` (code 86), because the existing index on the same key path has different options. The only workarounds today are dropping the index manually or sending a raw `createIndexes` command, both of which bypass the typed API.

## How Has This Been Tested?

Reproduced against a local MongoDB 7.0 instance using the typed `createIndexes` API with a `Collation`. Before the patch, `db.collection.getIndexes()` showed the new index without a `collation` field, and rerunning the same `createIndexes` call triggered `IndexKeySpecsConflict`. After the patch, the collation is persisted on the index as expected and the second call is a noop.

## Checklist:
* [ ] If applicable, I have updated the documentation accordingly.
* [ ] If applicable, I have added tests to cover my changes.